### PR TITLE
Hotfix: fix bids validate output data type in database

### DIFF
--- a/bids-validator/scripts/validate_dataset.py
+++ b/bids-validator/scripts/validate_dataset.py
@@ -199,12 +199,12 @@ def main():
             dataset_geid=dataset_id,
             created_time=current_time,
             updated_time=current_time,
-            validate_output=json.dumps(bids_output),
+            validate_output=bids_output,
         )
 
         do_update_bids = insert_bids.on_conflict_do_update(
             constraint='dataset_geid',
-            set_={DatasetModel.updated_time: current_time, DatasetModel.validate_output: json.dumps(bids_output)},
+            set_={DatasetModel.updated_time: current_time, DatasetModel.validate_output: bids_output},
             where=(DatasetModel.dataset_geid == dataset_id),
         )
         db_session.execute(do_update_bids)


### PR DESCRIPTION
## Summary

Hotfix: fix bids validate output data type in the database. The bids-validate output data type is wrong. It should be json but stored as string which cause the frontend issue


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)