### PR TITLE
fix to copy when versioning is not supported

### DIFF
--- a/filecopy/operations/services/metadata/client.py
+++ b/filecopy/operations/services/metadata/client.py
@@ -28,7 +28,6 @@ from operations.models import NodeList
 from operations.models import ResourceType
 from operations.models import ZoneType
 from requests import Session
-from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
@@ -243,7 +242,7 @@ class MetadataServiceClient:
                 result = loop.run_until_complete(
                     minio_client.copy_object(target_bucket, target_obj_path, src_bucket, src_obj_path)
                 )
-                version_id = result.get('VersionId', str(UUID(int=0))) # 0-UUID in case versioning is unsupported
+                version_id = result.get('VersionId', '') # empty in case versioning is unsupported
             else:
                 logger.info('File size greater than 5GiB')
                 temp_path = self.temp_dir + str(time.time())
@@ -253,7 +252,7 @@ class MetadataServiceClient:
                 result = loop.run_until_complete(
                     minio_client.upload_object(target_bucket, target_obj_path, temp_file_path)
                 )
-                version_id = result.get('VersionId', str(UUID(int=0))) # 0-UUID in case versioning is unsupported
+                version_id = result.get('VersionId', '') # empty in case versioning is unsupported
 
             logger.info(f'Minio Copy {src_bucket}/{src_obj_path} Success')
             payload['version'] = version_id

--- a/filecopy/operations/services/metadata/client.py
+++ b/filecopy/operations/services/metadata/client.py
@@ -28,6 +28,7 @@ from operations.models import NodeList
 from operations.models import ResourceType
 from operations.models import ZoneType
 from requests import Session
+from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +243,7 @@ class MetadataServiceClient:
                 result = loop.run_until_complete(
                     minio_client.copy_object(target_bucket, target_obj_path, src_bucket, src_obj_path)
                 )
-                version_id = result['VersionId']
+                version_id = result.get('VersionId', str(UUID(int=0))) # 0-UUID in case versioning is unsupported
             else:
                 logger.info('File size greater than 5GiB')
                 temp_path = self.temp_dir + str(time.time())
@@ -252,7 +253,7 @@ class MetadataServiceClient:
                 result = loop.run_until_complete(
                     minio_client.upload_object(target_bucket, target_obj_path, temp_file_path)
                 )
-                version_id = result['VersionId']
+                version_id = result.get('VersionId', str(UUID(int=0))) # 0-UUID in case versioning is unsupported
 
             logger.info(f'Minio Copy {src_bucket}/{src_obj_path} Success')
             payload['version'] = version_id

--- a/filecopy/operations/services/metadata/client.py
+++ b/filecopy/operations/services/metadata/client.py
@@ -242,7 +242,7 @@ class MetadataServiceClient:
                 result = loop.run_until_complete(
                     minio_client.copy_object(target_bucket, target_obj_path, src_bucket, src_obj_path)
                 )
-                version_id = result.get('VersionId', '') # empty in case versioning is unsupported
+                version_id = result.get('VersionId', '')  # empty in case versioning is unsupported
             else:
                 logger.info('File size greater than 5GiB')
                 temp_path = self.temp_dir + str(time.time())
@@ -252,7 +252,7 @@ class MetadataServiceClient:
                 result = loop.run_until_complete(
                     minio_client.upload_object(target_bucket, target_obj_path, temp_file_path)
                 )
-                version_id = result.get('VersionId', '') # empty in case versioning is unsupported
+                version_id = result.get('VersionId', '')  # empty in case versioning is unsupported
 
             logger.info(f'Minio Copy {src_bucket}/{src_obj_path} Success')
             payload['version'] = version_id


### PR DESCRIPTION
## Summary

When versioning in not supported by object storage, it sets the 0-UUID instead. Should be backwards compatible. 

## JIRA Issues

N/A

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [x] No

## Test Directions

Do integration testing in Azure env. 